### PR TITLE
Autobind component class methods and getters/getters

### DIFF
--- a/src/BaseReactiveComponent.js
+++ b/src/BaseReactiveComponent.js
@@ -1,37 +1,11 @@
 import { html, svg, render } from '../../web_modules/uhtml/esm/index.js';
-// import * as µhtml from '../../web_modules/uhtml/esm/index.js';
+import { RenderQueue } from './RenderQueue.js';
 
 const colors = {
   blue: '#1877f2',
   green: 'MediumSeaGreen',
   greyLight: '#dee5ec',
 };
-
-const queue = new class Queue {
-
-  #componentsToRender = new Set();
-
-  constructor () {
-    setInterval(() => {
-      if (this.#componentsToRender.size) {
-        this.tick();
-      }
-    }, 5);
-  }
-
-  tick () {
-    for (const component of this.#componentsToRender) {
-      component.render();
-    }
-
-    this.#componentsToRender.clear();
-  }
-
-  render (component) {
-    this.#componentsToRender.add(component);
-  }
-
-}
 
 class BaseReactiveComponent {
 
@@ -93,11 +67,11 @@ class BaseReactiveComponent {
 
         switch (this.renderStrategy) {
           case 'defer':
-            // Queue prevents double renders when changing multiple reactive variables in a row.
-            queue.render(this);
+            // RenderQueue prevents double renders when changing multiple reactive variables in a row.
+            RenderQueue.render(this);
             break;
           case 'immediately':
-            // Don't defer renders
+            // Don't use RenderQueue, just render immediately instead.
             this.render();
             break;
           default:

--- a/src/BaseReactiveComponent.js
+++ b/src/BaseReactiveComponent.js
@@ -39,6 +39,18 @@ class BaseReactiveComponent {
     return 'defer'; // defer|immediately
   }
 
+  autobind () {
+    for (const [propertyName, propertyDescriptor] of Object.entries(Object.getOwnPropertyDescriptors(this.constructor.prototype))) {
+      if (propertyName === 'constructor') continue;
+      // console.log(propertyName, propertyDescriptor);
+      if (typeof propertyDescriptor.value === 'function') {
+        propertyDescriptor.value = propertyDescriptor.value.bind(this);
+        Object.defineProperty(this.constructor.prototype, propertyName, propertyDescriptor);
+        console.log(`Autobound ${propertyName} to ${this.constructor.name}`);
+      }
+    }
+  }
+
   // Makes a data object 'reactive'.
   // NOTE: Will probably only trigger reactivity when Object values are reassigned, not when deeper objects are mutated.
   reactive (data) {

--- a/src/RenderQueue.js
+++ b/src/RenderQueue.js
@@ -1,0 +1,23 @@
+export const RenderQueue = new class RenderQueue {
+
+  #componentsToRender = new Set();
+  doTick = this.tick.bind(this);
+
+  constructor () {
+    requestAnimationFrame(this.doTick);
+  }
+
+  tick () {
+    for (const component of this.#componentsToRender) {
+      component.render();
+    }
+
+    this.#componentsToRender.clear();
+    requestAnimationFrame(this.doTick);
+  }
+
+  render (component) {
+    this.#componentsToRender.add(component);
+  }
+
+}

--- a/src/define.js
+++ b/src/define.js
@@ -1,6 +1,16 @@
 import { BaseReactiveComponent } from './BaseReactiveComponent.js';
 
 export function define (componentName, component, extendsElement) {
+  // for (const [propertyName, propertyDescriptor] of Object.entries(Object.getOwnPropertyDescriptors(component.prototype))) {
+  //   if (propertyName === 'constructor') continue;
+  //   console.log(propertyName, propertyDescriptor);
+  //   if (typeof propertyDescriptor.value === 'function') {
+  //     propertyDescriptor.value = propertyDescriptor.value.bind(component.prototype);
+  //     Object.defineProperty(component.prototype, propertyName, propertyDescriptor);
+  //     console.log(`Autobound ${propertyName} to ${component.prototype.constructor.name}`);
+  //   }
+  // }
+
   // Apply prototype of class BaseReactiveComponent on component
   for (const [propertyName, propertyDescriptor] of Object.entries(Object.getOwnPropertyDescriptors(BaseReactiveComponent.prototype))) {
     if (!(propertyName in component.prototype)) {

--- a/src/define.js
+++ b/src/define.js
@@ -1,16 +1,6 @@
 import { BaseReactiveComponent } from './BaseReactiveComponent.js';
 
 export function define (componentName, component, extendsElement) {
-  // for (const [propertyName, propertyDescriptor] of Object.entries(Object.getOwnPropertyDescriptors(component.prototype))) {
-  //   if (propertyName === 'constructor') continue;
-  //   console.log(propertyName, propertyDescriptor);
-  //   if (typeof propertyDescriptor.value === 'function') {
-  //     propertyDescriptor.value = propertyDescriptor.value.bind(component.prototype);
-  //     Object.defineProperty(component.prototype, propertyName, propertyDescriptor);
-  //     console.log(`Autobound ${propertyName} to ${component.prototype.constructor.name}`);
-  //   }
-  // }
-
   // Apply prototype of class BaseReactiveComponent on component
   for (const [propertyName, propertyDescriptor] of Object.entries(Object.getOwnPropertyDescriptors(BaseReactiveComponent.prototype))) {
     if (!(propertyName in component.prototype)) {

--- a/src/example.js
+++ b/src/example.js
@@ -75,6 +75,11 @@ define('example-element', class ExampleElement extends HTMLElement {
     `;
   }.bind(this);
 
+  constructor () {
+    super();
+    this.autobind();
+  }
+
   add () {
     this.data.count++;
   }

--- a/src/example.js
+++ b/src/example.js
@@ -14,9 +14,9 @@ define('time-passed', class TimePassed extends HTMLElement {
     seconds: 0,
   });
 
-  renderFunction = function () {
+  get template () {
     return this.html`<p>Seconds passed: ${this.data.seconds}</p>`;
-  }.bind(this);
+  }
 
   connectedCallback () {
     this.render();
@@ -54,30 +54,27 @@ define('example-element', class ExampleElement extends HTMLElement {
     timerPaused: false,
   });
 
-  renderFunction = function () {
+  get template () {
+    const { data } = this;
+
     return this.html`
       <h2>🎉 Reactive µhtml web components!</h2>
       <h3>A simple counter</h3>
-      <p>Count: ${this.data.count}</strong><br/>
-      <button onclick="${this.add.bind(this)}">Add</button>
-      <button onclick="${this.remove.bind(this)}" disabled="${this.data.count === 0 || null }">Remove</button></p>
+      <p>Count: ${data.count}</strong><br/>
+      <button onclick="${this.add}">Add</button>
+      <button onclick="${this.remove}" disabled="${data.count === 0 || null }">Remove</button></p>
 
       <h3>A nested reactive web component</h3>
-      <time-passed paused="${this.data.timerPaused}"/>
+      <time-passed paused="${data.timerPaused}"/>
 
       <h3>Control other web component's attributes</h3>
       <input
         id="timer-paused"
         type="checkbox"
-        checked="${this.data.timerPaused ? 'checked' : null}"
-        onclick="${() => { this.data.timerPaused = !this.data.timerPaused; }}"
+        checked="${data.timerPaused ? 'checked' : null}"
+        onclick="${() => { data.timerPaused = !data.timerPaused; }}"
       /><label for="timer-paused">Pause timer</label>
     `;
-  }.bind(this);
-
-  constructor () {
-    super();
-    this.autobind();
   }
 
   add () {


### PR DESCRIPTION
Autobind component class methods and getters/setters, so folks can use methods in their templates without having to do `this.method.bind(this)`, becaude that creates overhead and it's less performant/uses more memory (theoretically), since every time the component is rendered, a new function is created with `.bind()`.

Also changed:
- Renamed Queue to RenderQueue and turned `setInterval` into `requestAnimationFrame`.
- Getter `template` instead of a bound `renderFunction` property.
- Some cleaning up and refactoring.